### PR TITLE
Prevents bad size calculations by avoiding end-of-line spaces

### DIFF
--- a/MSLabel.m
+++ b/MSLabel.m
@@ -68,14 +68,18 @@
     NSMutableArray *slicedString = [NSMutableArray array];
     
     while (stringsArray.count != 0) {
-        NSString *line = [NSString stringWithString:@""];
+        NSString *line = @"";
         NSMutableIndexSet *wordsToRemove = [NSMutableIndexSet indexSet];
         
         for (int i = 0; i < [stringsArray count]; i++) {
             NSString *word = [stringsArray objectAtIndex:i];
             
-            if ([[line stringByAppendingFormat:@"%@ ", word] sizeWithFont:self.font].width <= self.frame.size.width) {
-                line = [line stringByAppendingFormat:@"%@ ", word];
+            if(i == 0 && [[line stringByAppendingString:word] sizeWithFont:self.font].width <= self.frame.size.width) {
+                line = [line stringByAppendingString:word];
+                [wordsToRemove addIndex:i];
+            }
+            else if ([[line stringByAppendingFormat:@" %@", word] sizeWithFont:self.font].width <= self.frame.size.width) {
+                line = [line stringByAppendingFormat:@" %@", word];
                 [wordsToRemove addIndex:i];
             } else {
                 if (line.length == 0) {

--- a/MSLabel.m
+++ b/MSLabel.m
@@ -73,17 +73,14 @@
         
         for (int i = 0; i < [stringsArray count]; i++) {
             NSString *word = [stringsArray objectAtIndex:i];
+            NSString *append = (i == 0 ? word : [NSString stringWithFormat:@" %@", word]);
             
-            if(i == 0 && [[line stringByAppendingString:word] sizeWithFont:self.font].width <= self.frame.size.width) {
-                line = [line stringByAppendingString:word];
-                [wordsToRemove addIndex:i];
-            }
-            else if ([[line stringByAppendingFormat:@" %@", word] sizeWithFont:self.font].width <= self.frame.size.width) {
-                line = [line stringByAppendingFormat:@" %@", word];
+            if ([[line stringByAppendingString:append] sizeWithFont:self.font].width <= self.frame.size.width) {
+                line = [line stringByAppendingString:append];
                 [wordsToRemove addIndex:i];
             } else {
                 if (line.length == 0) {
-                    line = [line stringByAppendingFormat:@"%@ ", word];
+                    line = [line stringByAppendingString:append];
                     [wordsToRemove addIndex:i];
                 }
                 break;


### PR DESCRIPTION
...ne spaces

Added a condition for the first word in each line to not add a space,
and then subsequent words add the space before.  This makes it so that
the last word on each line doesn't have an ending space in its size
calculation.  I was running into issues where the number of lines
calculations were not accurate due to this space.
