### PR TITLE
Adding verticalAlignment property & removed need for space to trigger new line

### DIFF
--- a/MSLabel.h
+++ b/MSLabel.h
@@ -9,10 +9,10 @@
 #import <UIKit/UIKit.h>
 
 typedef enum {
-    MSLabelVerticalAlignTop,
-    MSLabelVerticalAlignMiddle,
-    MSLabelVerticalAlignBottom
-} MSLabelVerticalAlign;
+    MSLabelVerticalAlignmentTop,
+    MSLabelVerticalAlignmentMiddle,
+    MSLabelVerticalAlignmentBottom
+} MSLabelVerticalAlignment;
 
 @interface MSLabel : UILabel 
 {
@@ -20,6 +20,6 @@ typedef enum {
 }
 
 @property (nonatomic, assign) int lineHeight;
-@property (nonatomic, assign) MSLabelVerticalAlign verticalAlign;
+@property (nonatomic, assign) MSLabelVerticalAlignment verticalAlignment;
 
 @end

--- a/MSLabel.h
+++ b/MSLabel.h
@@ -8,11 +8,18 @@
 
 #import <UIKit/UIKit.h>
 
-@interface MSLabel : UILabel {
+typedef enum {
+    MSLabelVerticalAlignTop,
+    MSLabelVerticalAlignMiddle,
+    MSLabelVerticalAlignBottom
+} MSLabelVerticalAlign;
+
+@interface MSLabel : UILabel 
+{
     int _lineHeight;
-    BOOL _anchorBottom;
 }
 
 @property (nonatomic, assign) int lineHeight;
-@property (nonatomic, assign) BOOL anchorBottom;
+@property (nonatomic, assign) MSLabelVerticalAlign verticalAlign;
+
 @end

--- a/MSLabel.m
+++ b/MSLabel.m
@@ -8,6 +8,9 @@
 
 #import "MSLabel.h"
 
+// small buffer to allow for characters like g,y etc 
+static const int kAlignBuffer = 5;
+
 @interface MSLabel ()
 
 - (void)setup;
@@ -61,7 +64,7 @@
         numLines = self.numberOfLines;
     }
     
-    int drawY = self.frame.size.height / 2 - (_lineHeight * numLines) / 2;    
+    int drawY = (self.frame.size.height / 2 - (_lineHeight * numLines) / 2) - kAlignBuffer;    
     
     for (int i = 0; i < numLines; i++) 
     {        
@@ -86,7 +89,7 @@
                 break;
             case MSLabelVerticalAlignBottom:
             {
-                drawY = self.frame.size.height - ((i + 1) * _lineHeight);
+                drawY = (self.frame.size.height - ((i + 1) * _lineHeight)) - kAlignBuffer;
             }
                 break;
             default:
@@ -135,7 +138,7 @@
 - (void)setup
 {
     _lineHeight = 10;
-    _verticalAlign = MSLabelVerticalAlignMiddle;
+    _verticalAlign = MSLabelVerticalAlignBottom;
 }
 
 - (NSArray *)stringsFromText:(NSString *)string 

--- a/MSLabel.m
+++ b/MSLabel.m
@@ -32,24 +32,35 @@
     NSArray *slicedStrings = [self stringsFromText:self.text];
     [self.textColor set];
     
-    for (int i = 0; i < slicedStrings.count; i++) {
-        if (i + 1 > self.numberOfLines && self.numberOfLines != 0)
-            break;
-        
+    int numLines = slicedStrings.count;
+    if (numLines > self.numberOfLines && self.numberOfLines != 0)
+    {
+        numLines = self.numberOfLines;
+    }
+    int drawHeight = self.frame.size.height / 2 - (_lineHeight * numLines) / 2;
+    int drawPos = drawHeight;
+    for (int i = 0; i < numLines; i++) {        
         NSString *line = [slicedStrings objectAtIndex:i];
         
         // calculate drawHeight based on anchor
-        int drawHeight = _anchorBottom ? (self.frame.size.height - (slicedStrings.count - i) * _lineHeight) : i * _lineHeight;        
+        //int drawHeight = ((self.frame.size.height - ((slicedStrings.count - i) * _lineHeight) ) / 2 ); 
+        
+        if(i > 0)
+        {
+            drawPos += _lineHeight;            
+        }
+        
+        //drawHeight = drawHeight + _lineHeight * slicedStrings.count - i;
         
         // calculate drawWidth based on textAlignment
-        int drawWidth = 0;
+        int drawWidth = 0; 
         if (self.textAlignment == UITextAlignmentCenter) {
             drawWidth = floorf((self.frame.size.width - [line sizeWithFont:self.font].width) / 2);
         } else if (self.textAlignment == UITextAlignmentRight) {
             drawWidth = (self.frame.size.width - [line sizeWithFont:self.font].width);
         }
         
-        [line drawAtPoint:CGPointMake(drawWidth, drawHeight) forWidth:self.frame.size.width withFont:self.font fontSize:self.font.pointSize lineBreakMode:UILineBreakModeClip baselineAdjustment:UIBaselineAdjustmentNone];
+        [line drawAtPoint:CGPointMake(drawWidth, drawPos) forWidth:self.frame.size.width withFont:self.font fontSize:self.font.pointSize lineBreakMode:UILineBreakModeClip baselineAdjustment:UIBaselineAdjustmentNone];
     }
 }
 
@@ -63,33 +74,52 @@
 
 #pragma mark - Private Methods
 
-- (NSArray *)stringsFromText:(NSString *)string {
-    NSMutableArray *stringsArray = [[[string componentsSeparatedByString:@" "] mutableCopy] autorelease];
+- (NSArray *)stringsFromText:(NSString *)string 
+{
+    
+    NSRange theRange = {0, 1};
+    
+    NSMutableArray *stringsArray  = [NSMutableArray array];
+    
+    for ( NSInteger i = 0; i < [string length]; i++) 
+    {
+        theRange.location = i;
+        [stringsArray addObject:[string substringWithRange:theRange]];
+    }
+    
     NSMutableArray *slicedString = [NSMutableArray array];
     
-    while (stringsArray.count != 0) {
+    while (stringsArray.count != 0) 
+    {
         NSString *line = [NSString stringWithString:@""];
         NSMutableIndexSet *wordsToRemove = [NSMutableIndexSet indexSet];
         
-        for (int i = 0; i < [stringsArray count]; i++) {
+        for (int i = 0; i < [stringsArray count]; i++) 
+        {
             NSString *word = [stringsArray objectAtIndex:i];
             
-            if ([[line stringByAppendingFormat:@"%@ ", word] sizeWithFont:self.font].width <= self.frame.size.width) {
-                line = [line stringByAppendingFormat:@"%@ ", word];
+            if ([[line stringByAppendingFormat:@"%@", word] sizeWithFont:self.font].width <= self.frame.size.width) 
+            {
+                line = [line stringByAppendingFormat:@"%@", word];
                 [wordsToRemove addIndex:i];
-            } else {
-                if (line.length == 0) {
-                    line = [line stringByAppendingFormat:@"%@ ", word];
+            } 
+            else 
+            {
+                if (line.length == 0) 
+                {
+                    line = [line stringByAppendingFormat:@"%@", word];
                     [wordsToRemove addIndex:i];
                 }
                 break;
             }
         }
+        
         [slicedString addObject:[line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]]];
         [stringsArray removeObjectsAtIndexes:wordsToRemove];
     }
     
-    if (slicedString.count > self.numberOfLines && self.numberOfLines != 0) {
+    if (slicedString.count > self.numberOfLines && self.numberOfLines != 0) 
+    {
         NSString *line = [slicedString objectAtIndex:(self.numberOfLines - 1)];
         line = [line stringByReplacingCharactersInRange:NSMakeRange(line.length - 3, 3) withString:@"..."];
         [slicedString removeObjectAtIndex:(self.numberOfLines - 1)];

--- a/MSLabel.m
+++ b/MSLabel.m
@@ -10,25 +10,54 @@
 
 @interface MSLabel ()
 
+- (void)setup;
 - (NSArray *)stringsFromText:(NSString *)string;
 
 @end
 
 @implementation MSLabel
-@synthesize lineHeight=_lineHeight;
-@synthesize anchorBottom=_anchorBottom;
 
-- (id)initWithFrame:(CGRect)frame {
+@synthesize lineHeight = _lineHeight;
+@synthesize verticalAlign = _verticalAlign;
+
+
+#pragma mark - Initilisation
+
+- (id)initWithFrame:(CGRect)frame 
+{
     self = [super initWithFrame:frame];
     
-    if (self) {
-        _lineHeight = 10;
+    if (self) 
+    {
+        [self setup];
     }
     
     return self;
 }
 
-- (void)drawTextInRect:(CGRect)rect {
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    
+    if(self)
+    {
+        [self setup];
+    }
+    
+    return self;
+}
+
+- (void)setup
+{
+    _lineHeight = 10;
+    _verticalAlign = MSLabelVerticalAlignMiddle;
+}
+
+
+#pragma mark - Drawing
+
+- (void)drawTextInRect:(CGRect)rect 
+{
     NSArray *slicedStrings = [self stringsFromText:self.text];
     [self.textColor set];
     
@@ -37,40 +66,75 @@
     {
         numLines = self.numberOfLines;
     }
-    int drawHeight = self.frame.size.height / 2 - (_lineHeight * numLines) / 2;
-    int drawPos = drawHeight;
-    for (int i = 0; i < numLines; i++) {        
+    
+    int drawY = self.frame.size.height / 2 - (_lineHeight * numLines) / 2;    
+    
+    for (int i = 0; i < numLines; i++) 
+    {        
+        
         NSString *line = [slicedStrings objectAtIndex:i];
         
-        // calculate drawHeight based on anchor
-        //int drawHeight = ((self.frame.size.height - ((slicedStrings.count - i) * _lineHeight) ) / 2 ); 
-        
-        if(i > 0)
+        // calculate draw Y based on alignment
+        switch (_verticalAlign) 
         {
-            drawPos += _lineHeight;            
+            case MSLabelVerticalAlignTop:
+            {
+                drawY = i * _lineHeight;
+            }
+                break;
+            case MSLabelVerticalAlignMiddle:
+            {
+                if(i > 0)
+                {
+                    drawY += _lineHeight;            
+                }
+            }
+                break;
+            case MSLabelVerticalAlignBottom:
+            {
+                drawY = self.frame.size.height - ((i + 1) * _lineHeight);
+            }
+                break;
+            default:
+            {
+                if(i > 0)
+                {
+                    drawY += _lineHeight;            
+                }
+            }
+                break;
         }
         
-        //drawHeight = drawHeight + _lineHeight * slicedStrings.count - i;
+        // calculate draw X based on textAlignment
+        int drawX = 0; 
         
-        // calculate drawWidth based on textAlignment
-        int drawWidth = 0; 
-        if (self.textAlignment == UITextAlignmentCenter) {
-            drawWidth = floorf((self.frame.size.width - [line sizeWithFont:self.font].width) / 2);
-        } else if (self.textAlignment == UITextAlignmentRight) {
-            drawWidth = (self.frame.size.width - [line sizeWithFont:self.font].width);
+        if (self.textAlignment == UITextAlignmentCenter) 
+        {
+            drawX = floorf((self.frame.size.width - [line sizeWithFont:self.font].width) / 2);
+        } 
+        else if (self.textAlignment == UITextAlignmentRight) 
+        {
+            drawX = (self.frame.size.width - [line sizeWithFont:self.font].width);
         }
         
-        [line drawAtPoint:CGPointMake(drawWidth, drawPos) forWidth:self.frame.size.width withFont:self.font fontSize:self.font.pointSize lineBreakMode:UILineBreakModeClip baselineAdjustment:UIBaselineAdjustmentNone];
+        [line drawAtPoint:CGPointMake(drawX, drawY) forWidth:self.frame.size.width withFont:self.font fontSize:self.font.pointSize lineBreakMode:UILineBreakModeClip baselineAdjustment:UIBaselineAdjustmentNone];
     }
 }
 
+
 #pragma mark - Properties
 
-- (void)setLineHeight:(int)lineHeight {
-    if (_lineHeight == lineHeight) { return; }
+- (void)setLineHeight:(int)lineHeight 
+{
+    if (_lineHeight == lineHeight) 
+    { 
+        return; 
+    }
+    
     _lineHeight = lineHeight;
     [self setNeedsDisplay];
 }
+
 
 #pragma mark - Private Methods
 

--- a/MSLabel.m
+++ b/MSLabel.m
@@ -9,7 +9,7 @@
 #import "MSLabel.h"
 
 // small buffer to allow for characters like g,y etc 
-static const int kAlignBuffer = 5;
+static const int kAlignmentBuffer = 5;
 
 @interface MSLabel ()
 
@@ -21,7 +21,7 @@ static const int kAlignBuffer = 5;
 @implementation MSLabel
 
 @synthesize lineHeight = _lineHeight;
-@synthesize verticalAlign = _verticalAlign;
+@synthesize verticalAlignment = _verticalAlignment;
 
 
 #pragma mark - Initilisation
@@ -64,7 +64,7 @@ static const int kAlignBuffer = 5;
         numLines = self.numberOfLines;
     }
     
-    int drawY = (self.frame.size.height / 2 - (_lineHeight * numLines) / 2) - kAlignBuffer;    
+    int drawY = (self.frame.size.height / 2 - (_lineHeight * numLines) / 2) - kAlignmentBuffer;    
     
     for (int i = 0; i < numLines; i++) 
     {        
@@ -72,14 +72,14 @@ static const int kAlignBuffer = 5;
         NSString *line = [slicedStrings objectAtIndex:i];
         
         // calculate draw Y based on alignment
-        switch (_verticalAlign) 
+        switch (_verticalAlignment) 
         {
-            case MSLabelVerticalAlignTop:
+            case MSLabelVerticalAlignmentTop:
             {
                 drawY = i * _lineHeight;
             }
                 break;
-            case MSLabelVerticalAlignMiddle:
+            case MSLabelVerticalAlignmentMiddle:
             {
                 if(i > 0)
                 {
@@ -87,9 +87,9 @@ static const int kAlignBuffer = 5;
                 }
             }
                 break;
-            case MSLabelVerticalAlignBottom:
+            case MSLabelVerticalAlignmentBottom:
             {
-                drawY = (self.frame.size.height - ((i + 1) * _lineHeight)) - kAlignBuffer;
+                drawY = (self.frame.size.height - ((i + 1) * _lineHeight)) - kAlignmentBuffer;
             }
                 break;
             default:
@@ -102,7 +102,7 @@ static const int kAlignBuffer = 5;
                 break;
         }
         
-        // calculate draw X based on textAlignment
+        // calculate draw X based on textAlignmentment
         int drawX = 0; 
         
         if (self.textAlignment == UITextAlignmentCenter) 
@@ -138,7 +138,7 @@ static const int kAlignBuffer = 5;
 - (void)setup
 {
     _lineHeight = 10;
-    _verticalAlign = MSLabelVerticalAlignBottom;
+    _verticalAlignment = MSLabelVerticalAlignmentMiddle;
 }
 
 - (NSArray *)stringsFromText:(NSString *)string 

--- a/MSLabel.m
+++ b/MSLabel.m
@@ -47,12 +47,6 @@
     return self;
 }
 
-- (void)setup
-{
-    _lineHeight = 10;
-    _verticalAlign = MSLabelVerticalAlignMiddle;
-}
-
 
 #pragma mark - Drawing
 
@@ -137,6 +131,12 @@
 
 
 #pragma mark - Private Methods
+
+- (void)setup
+{
+    _lineHeight = 10;
+    _verticalAlign = MSLabelVerticalAlignMiddle;
+}
 
 - (NSArray *)stringsFromText:(NSString *)string 
 {


### PR DESCRIPTION
A number of major changes:
- Added the verticalAlignment property, options are: 
  
  `MSLabelVerticalAlignmentTop`
  `MSLabelVerticalAlignmentMiddle`
  `MSLabelVerticalAlignmentBottom`
- Removed the need for a white space to trigger a new line, new lines are now triggered whenever the width limit is met regardless of a space being entered in the string. 
- Had a major spring clean to increase readability 
- Added the `setup` private method to set defaults
- Overwritten `initWithCoder:` so labels loaded from nibs set defaults
- Removed the `anchorBottom` BOOL (the vertical alignment enum is a lot more powerful and robust)
- Added a slight buffer to allow for characters like: `y g p` being clipped when aligned bottom. 
