### PR TITLE
Fixing new line calculation bug

### DIFF
--- a/MSLabel.m
+++ b/MSLabel.m
@@ -148,7 +148,7 @@ static const int kAlignmentBuffer = 5;
     
     while (stringsArray.count != 0) 
     {
-        NSString *line = [NSString stringWithString:@""];
+        NSString *line = @"";
         NSMutableIndexSet *wordsToRemove = [NSMutableIndexSet indexSet];
         
         for (int i = 0; i < [stringsArray count]; i++) 

--- a/MSLabel.m
+++ b/MSLabel.m
@@ -155,7 +155,7 @@ static const int kAlignmentBuffer = 5;
         {
             NSString *word = [stringsArray objectAtIndex:i];
             
-            if ([[line stringByAppendingFormat:@"%@ ", word] sizeWithFont:self.font].width <= self.frame.size.width) 
+            if ([[line stringByAppendingFormat:@"%@", word] sizeWithFont:self.font].width <= self.frame.size.width) 
             {
                 line = [line stringByAppendingFormat:@"%@ ", word];
                 [wordsToRemove addIndex:i];

--- a/MSLabel.m
+++ b/MSLabel.m
@@ -17,7 +17,6 @@ static const int kAlignmentBuffer = 5;
 
 - (void)setup;
 - (NSArray *)stringsFromText:(NSString *)string;
-- (NSString *)stringByTruncatingString:(NSString *)string toWidth:(CGFloat)width withFont:(UIFont*)font;
 - (NSMutableArray *)stringsWithWordsWrappedFromArray:(NSArray *)strings;
 - (NSMutableArray *)arrayOfCharactersInString:(NSString *)string;
 - (NSString *)lastWordInString:(NSString *)string;
@@ -244,21 +243,6 @@ static const int kAlignmentBuffer = 5;
     }
     
     return lastWord;
-}
-
-- (NSString *)stringByTruncatingString:(NSString *)string toWidth:(CGFloat)width withFont:(UIFont*)font
-{
-    NSMutableString *resultString = [[string mutableCopy] autorelease];
-    NSRange range = {resultString.length-1, 1};
-    
-    while ([resultString sizeWithFont:font].width > width) {
-        // delete the last character
-        [resultString deleteCharactersInRange:range];
-        range.location--;
-        // replace the last but one character with an ellipsis
-        //[resultString replaceCharactersInRange:range withString:string];
-    }
-    return resultString;
 }
 
 - (NSMutableArray *)arrayOfCharactersInString:(NSString *)string

--- a/MSLabel.m
+++ b/MSLabel.m
@@ -145,7 +145,8 @@ static const int kAlignmentBuffer = 5;
 
 - (void)setup
 {
-    _lineHeight = 10;
+    _lineHeight = 12;
+    self.minimumFontSize = 12;
     _verticalAlignment = MSLabelVerticalAlignmentMiddle;
 }
 
@@ -162,8 +163,22 @@ static const int kAlignmentBuffer = 5;
         for (int i = 0; i < [characterArray count]; i++)
         {
             NSString *character = [characterArray objectAtIndex:i];
+            CGFloat stringWidth = [[line stringByAppendingFormat:@"%@", character] sizeWithFont:self.font].width;
             
-            if ([[line stringByAppendingFormat:@"%@", character] sizeWithFont:self.font].width <= (self.frame.size.width - 10))
+            // shrink font to fit text as best as we can
+            if(stringWidth > (self.frame.size.width - 10))
+            {
+                CGFloat fontSize = self.font.pointSize;
+                
+                while(stringWidth > (self.frame.size.width - 10) && fontSize >= self.minimumFontSize)
+                {
+                    self.font = [UIFont fontWithName:self.font.fontName size:fontSize--];
+                    _lineHeight = self.font.pointSize;
+                    stringWidth = [[line stringByAppendingFormat:@"%@", character] sizeWithFont:self.font].width;
+                }
+            }
+            
+            if (stringWidth <= (self.frame.size.width - 10))
             {
                 line = [line stringByAppendingFormat:@"%@", character];
                 [charsToRemove addIndex:i];
@@ -175,6 +190,7 @@ static const int kAlignmentBuffer = 5;
                     line = [line stringByAppendingFormat:@"%@", character];
                     [charsToRemove addIndex:i];
                 }
+                
                 break;
             }
         }


### PR DESCRIPTION
The new line calculation was taking into account an extra space where it did not need to. Therefore a linebreak would be inserted too early with some strings

`if ([[line stringByAppendingFormat:@"%@ ", word] sizeWithFont:self.font].width <= self.frame.size.width)`

Was calculating the string width with an extra space, updated it to:

`if ([[line stringByAppendingFormat:@"%@", word] sizeWithFont:self.font].width <= self.frame.size.width)`

So that new line breaks are not inserted too early for the string, whole words are still maintained on a new line. 
