### PR TITLE
Fixed MSLabelVerticalAlignmentBottom so text wasn't drawn upside down

### DIFF
--- a/MSLabel.m
+++ b/MSLabel.m
@@ -94,7 +94,7 @@ static const int kAlignmentBuffer = 5;
                 break;
             case MSLabelVerticalAlignmentBottom:
             {
-                drawY = (self.frame.size.height - ((i + 1) * _lineHeight)) - kAlignmentBuffer;
+                drawY = (self.frame.size.height - _lineHeight * numLines) + ((i  * _lineHeight) - kAlignmentBuffer);
             }
                 break;
             default:


### PR DESCRIPTION
The current implementation wrote, from bottom to top, Line A then B then C, etc.  

This resulted in the lines being in the wrong order.  

This commit calculates where the first line will start, then increments down by lineHeight in each iteration.  Thus, Line A is written first, then B, then C.
