### PR TITLE
UILineBreakModeWordWrap whitespace problem

### DIFF
--- a/MSLabel.m
+++ b/MSLabel.m
@@ -180,8 +180,12 @@ static const int kAlignmentBuffer = 5;
                 break;
             }
         }
-        
+      if (self.lineBreakMode == UILineBreakModeWordWrap) {
+        [slicedString addObject:line];
+      } else {
         [slicedString addObject:[line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]]];
+      }
+      
         [characterArray removeObjectsAtIndexes:charsToRemove];
     }
     


### PR DESCRIPTION
the problem is that in UILineBreakModeWordWrap, words on the successive lines stick together, because whitespaces are truncated regardless in line no 183.
So, I have made a small correction in the logic on line no 183, so that when the line breaking mode is UILineBreakModeWordWrap, the leading and trailing whitespaces are not truncated, otherwise they are truncated.

Now the words are correctly assembled back from the characters when the text width exceeds container width.

it seems to work fine with all the testing that I have done.

request to merge this change with your code.

... in UILineBreakModeWordWrap
